### PR TITLE
Expose system endianness

### DIFF
--- a/imsg.go
+++ b/imsg.go
@@ -164,3 +164,8 @@ func (im IMsg) MarshalBinary() ([]byte, error) {
 
 	return buf.Bytes(), nil
 }
+
+// SystemEndianness returns the determined system byte order.
+func SystemEndianness() binary.ByteOrder {
+	return endianness
+}

--- a/imsg_test.go
+++ b/imsg_test.go
@@ -213,3 +213,25 @@ func TestReadIMsg(t *testing.T) {
 	// Restore the determined system endianness
 	endianness = systemEndianness
 }
+
+func TestSystemEndianness(t *testing.T) {
+	// Store out the determined system endianness before manually manipulating it
+	systemEndianness := endianness
+
+	if endianness != SystemEndianness() {
+		t.Fatalf("determined endianness does not match expected value")
+	}
+
+	endianness = binary.LittleEndian
+	if endianness != SystemEndianness() {
+		t.Fatalf("determined endianness does not match expected value")
+	}
+
+	endianness = binary.BigEndian
+	if endianness != SystemEndianness() {
+		t.Fatalf("determined endianness does not match expected value")
+	}
+
+	// Restore the determined system endianness
+	endianness = systemEndianness
+}


### PR DESCRIPTION
Adds a helper function to retrieve determined system endianness. This is useful when serializing and deserializing binary data contained within an imsg.

## Example Usage
```go
package main

import (
  "log"

  "github.com/schultz-is/go-imsg"
)

func main() {
  log.Printf("Endianness: %s", imsg.SystemEndianness())
}
```

```console
$ go run main.go
2020/03/07 14:18:40 Endianness: LittleEndian
```