### PR TITLE
Add imsgHeader serialization helper

### DIFF
--- a/imsg.go
+++ b/imsg.go
@@ -120,30 +120,19 @@ func (im *IMsg) Len() int {
 func (im IMsg) MarshalBinary() ([]byte, error) {
 	var buf bytes.Buffer
 
-	err := binary.Write(&buf, endianness, im.Type)
-	if err != nil {
-		return nil, err
-	}
-
 	if im.Len() > MaxSizeInBytes {
 		return nil, errors.New("imsg: imsg exceeds maximum length")
 	}
-	err = binary.Write(&buf, endianness, uint16(im.Len()))
-	if err != nil {
-		return nil, err
+
+	hdr := imsgHeader{
+		Type:   im.Type,
+		Length: uint16(im.Len()),
+		Flags:  im.flags,
+		PeerID: im.PeerID,
+		PID:    im.PID,
 	}
 
-	err = binary.Write(&buf, endianness, im.flags)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, endianness, im.PeerID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = binary.Write(&buf, endianness, im.PID)
+	err := binary.Write(&buf, endianness, hdr)
 	if err != nil {
 		return nil, err
 	}

--- a/imsg.go
+++ b/imsg.go
@@ -40,6 +40,15 @@ func init() {
 	}
 }
 
+// This is a fixed-size header used to simplify marshaling and unmarshaling.
+type imsgHeader struct {
+	Type   uint32
+	Length uint16
+	Flags  uint16
+	PeerID uint32
+	PID    uint32
+}
+
 // An IMsg is a message used to aid inter-process communication over sockets,
 // often when processes with different privileges are required to cooperate.
 type IMsg struct {


### PR DESCRIPTION
Simplifies marshalling and unmarshalling with a fixed-length header. This allows a single call to `binary.Read()` or `binary.Write()` rather than once per field.