### PR TITLE
Run tests on pushes only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [ push, pull_request ]
+on: [ push ]
 
 jobs:
 


### PR DESCRIPTION
Seems excessive to run tests on both push and pull request.