### PR TITLE
Add length checks to ReadIMsg

### DIFF
--- a/imsg.go
+++ b/imsg.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"unsafe"
@@ -93,6 +94,14 @@ func ReadIMsg(r io.Reader) (*IMsg, error) {
 	err := binary.Read(r, endianness, &hdr)
 	if err != nil {
 		return nil, err
+	}
+
+	if hdr.Length < HeaderSizeInBytes {
+		return nil, fmt.Errorf("imsg: message length too small (%d bytes)", hdr.Length)
+	}
+
+	if hdr.Length > MaxSizeInBytes {
+		return nil, fmt.Errorf("imsg: message length too large (%d bytes)", hdr.Length)
 	}
 
 	im.Type = hdr.Type

--- a/imsg.go
+++ b/imsg.go
@@ -111,9 +111,14 @@ func ReadIMsg(r io.Reader) (*IMsg, error) {
 
 	if hdr.Length > HeaderSizeInBytes {
 		im.Data = make([]byte, hdr.Length-HeaderSizeInBytes)
-		_, err = r.Read(im.Data)
+
+		n, err := r.Read(im.Data)
 		if err != nil {
 			return nil, err
+		}
+
+		if n != int(hdr.Length)-HeaderSizeInBytes {
+			return nil, errors.New("imsg: could not read full message body")
 		}
 	}
 

--- a/imsg_test.go
+++ b/imsg_test.go
@@ -216,6 +216,15 @@ func TestReadIMsg(t *testing.T) {
 		t.Fatalf("incorrectly read an imsg with invalidly large length")
 	}
 
+	// Ensure messages smaller than the header size don't get unmershalled
+	buf = bytes.NewReader(
+		[]byte{0, 0, 0}, // smaller than the uint32 that describes the Type field
+	)
+	_, err = ReadIMsg(buf)
+	if err == nil {
+		t.Fatalf("incorrectly read a malformed imsg")
+	}
+
 	// Restore the determined system endianness
 	endianness = systemEndianness
 }

--- a/imsg_test.go
+++ b/imsg_test.go
@@ -216,6 +216,22 @@ func TestReadIMsg(t *testing.T) {
 		t.Fatalf("incorrectly read an imsg with invalidly large length")
 	}
 
+	buf = bytes.NewReader(
+		[]byte{
+			0, 0, 0, 0,
+			0, 0xff,
+			0, 0,
+			0, 0, 0, 0,
+			0, 0, 0, 0,
+
+			1, 2, 3, 4,
+		},
+	)
+	_, err = ReadIMsg(buf)
+	if err == nil {
+		t.Fatalf("incorrectly read an imsg with invalidly short ancillary data")
+	}
+
 	// Ensure messages smaller than the header size don't get unmershalled
 	buf = bytes.NewReader(
 		[]byte{0, 0, 0}, // smaller than the uint32 that describes the Type field

--- a/imsg_test.go
+++ b/imsg_test.go
@@ -192,6 +192,9 @@ func TestReadIMsg(t *testing.T) {
 		[]byte{
 			0, 0, 0, 0, // type
 			0, 0, // length < header size
+			0, 0, // flags
+			0, 0, 0, 0, // peer id
+			0, 0, 0, 0, // pid
 		},
 	)
 	_, err = ReadIMsg(buf)
@@ -203,6 +206,9 @@ func TestReadIMsg(t *testing.T) {
 		[]byte{
 			0, 0, 0, 0, // type
 			0xff, 0xff, // length > maximum size
+			0, 0, // flags
+			0, 0, 0, 0, // peer id
+			0, 0, 0, 0, // pid
 		},
 	)
 	_, err = ReadIMsg(buf)


### PR DESCRIPTION
`ReadIMsg()` should now return an error in the following cases:
- Parsed length parameter is less than the imsg header size
- Parsed length parameter is larger than the maximum allowed size
- Parsed length parameter is valid, but larger than the data provided by the supplied `io.Reader`